### PR TITLE
CVE-2024-27282 rubyメモリアドレス読み取りの脆弱性に対応するため ruby 3.2.4へアップグレード

### DIFF
--- a/node16/Dockerfile
+++ b/node16/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:16.20.2-bullseye AS node-16
 
-FROM ruby:3.2.3-bullseye
+FROM ruby:3.2.4-bullseye
 
 ENV LANG C.UTF-8
 

--- a/node18/Dockerfile
+++ b/node18/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:18.19.0-bullseye AS node-18
 
-FROM ruby:3.2.3-bullseye
+FROM ruby:3.2.4-bullseye
 
 WORKDIR /app
 


### PR DESCRIPTION
# 概要
ruby 3.2.3 で正規表現（Regex）検索に任意のメモリアドレスを読み取られる脆弱性が発見されたため ruby 3.2.4 へアップグレード
https://www.ruby-lang.org/en/news/2024/04/23/arbitrary-memory-address-read-regexp-cve-2024-27282/