### PR TITLE
Ruby 3.3.5 へアップグレード

### DIFF
--- a/node16/Dockerfile
+++ b/node16/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:16.20.2-bullseye AS node-16
 
-FROM ruby:3.2.4-bullseye
+FROM ruby:3.3.5-bullseye
 
 ENV LANG C.UTF-8
 
@@ -57,3 +57,4 @@ RUN wget https://noto-website-2.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted
 
 RUN pip3 install awscli --upgrade --user
 RUN echo "export PATH=~/.local/bin:$PATH" >> ~/.bashrc
+

--- a/node18/Dockerfile
+++ b/node18/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 FROM node:18.20.2-bullseye AS node
 
-FROM ruby:3.2.3-bullseye
+FROM ruby:3.3.5-bullseye
 
 # Let NodeModules install into /pnpm.
 ENV PNPM_HOME=/pnpm
@@ -38,3 +38,4 @@ RUN <<EOF
   yarn --version
   corepack --version
 EOF
+


### PR DESCRIPTION
ローカル環境で利用するDocker ImageのRubyバージョンを更新しました。
実際の利用に際してはタグ付けしたものでダウンロードが走るので、
マージしたら Ruby 3.3.5 に切り替わると言うわけではないのですぐにマージしたいです！